### PR TITLE
Added `event.context` for response to 'callbackURL' response to make …

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,21 @@ You should have the following packages locally installed:
     $ docker run -v "$PWD":/var/task lambci/lambda:build-nodejs6.10 npm install --prefix=lambda
     ```
 
-- The [AWS SAM Local][aws_sam_local] CLI tool for local development and testing of Serverless applications.
+- The [AWS SAM Local][aws_sam_local] CLI tool for local development and testing.
 
 
 ## Usage
 
 ### Local testing
 
-To invoke the function using the [AWS SAM Local][aws_sam_local] package with an [AWS credentials profile][aws_profile] 
-with a event.json 
-fixture 
-file, run the following command:
+First, install globally the [AWS SAM Local][aws_sam_local] package.
+
+```
+$ npm install -g aws-sam-local
+```
+
+To invoke the Lambda function using the [AWS SAM Local][aws_sam_local] with an [AWS credentials profile][aws_profile] 
+with a event.json fixture file, run the following command:
 
 ```
 $ sam local invoke "ImageResizeOnDemand" -e event.json -profile texpert

--- a/event.json
+++ b/event.json
@@ -2,15 +2,15 @@
   [
     { "cache": { "name": "texpert-test-cache",
                  "prefix": "cache" },
-    "store":   { "name": "texpert-test-store",
+      "store": { "name": "texpert-test-store",
                  "prefix": "store" }
     }
   ],
   "path": "user/36985/document/14/doc/d46bd213658257d4913247d62d74760f.png",
-  "callbackURL": "http://docker.for.mac.localhost:3000/rapi/lambda",
+  "callbackURL": "http://texpert.localtunnel.me/rapi/lambda",
+  "targetStorage": "store",
   "original": { "id": "aurel.png",
                 "storage": "cache",
-                "targetStorage": "store",
                 "metadata": {
                   "size": 64684,
                   "filename": "aurel.png",


### PR DESCRIPTION
…the backend aware of the `record_id and class` of the original file.

Do not initialize redundant local variables for `callbackURL` and `versions` for single usage - just referencing them from the `event` object is enough.

`targetStorage` is sent not in the `original` file's context, but as an `event`'s key.

Changed the 'callbackURL' in the sample event.json file to a `localtunnel.me` URL which is working crossplatform.

Added to README.md the instruction to install `aws-sam-local` package.