### PR TITLE
Receiving the key to sign the requests to the `callbackURL` in the `a…

### DIFF
--- a/event.json
+++ b/event.json
@@ -13,6 +13,7 @@
                   "metadata": {
                     "size": 64684,
                     "filename": "aurel.png",
+                    "key": "big_secret",
                     "mime_type": "image/png" }
   },
   "versions":


### PR DESCRIPTION
…ttachment.metadata.key` string.

Also got rid of the Lambda callback - it has no sense to explicitely define it calling a Lambda in async `Event` mode - it will automatically return a 202 status on success.
